### PR TITLE
Changing the order of the data results in different plots

### DIFF
--- a/R/shadowtext-grob.R
+++ b/R/shadowtext-grob.R
@@ -41,7 +41,7 @@ shadowtextGrob <- function(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
     gp$col <- bg.colour
 
     theta <- seq(pi/8, 2*pi, length.out=16)
-    char <- substring(label[1], 1, 1)
+    char <- "X"
     r <- bg.r[1]
 
     bgList <- lapply(theta, function(i) {
@@ -50,7 +50,7 @@ shadowtextGrob <- function(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
         if (!is.unit(y))
             y <- unit(y, default.units)
 
-        x <- x + unit(cos(i) * r, "strwidth", data = char)
+        x <- x + unit(cos(i) * r, "strheight", data = char)
         y <- y + unit(sin(i) * r, "strheight", data = char)
         textGrob(label = label, x = x, y = y, just = just, hjust = hjust,
                  vjust = vjust, rot = rot, default.units = default.units,


### PR DESCRIPTION
Hello @GuangchuangYu !

I noticed a strange effect when the label of the first row of my data starts with an 'i', 'l', or 'I'. In the plot below, I exaggerated the `bg.r` value to make the problem more apparent.

```r
library(ggplot2)
library(shadowtext) # load CRAN version
library(patchwork)

data <- data.frame(i = c(1,2), s = c("I", "Z"))
baseg <- ggplot(data, aes(0, i, label = s)) + expand_limits(y = c(.5, 2.5))

g1 <- 
  baseg + 
  geom_shadowtext(bg.r = 1, size = 10, colour = "red") + 
  labs(title = "before: I is first")

g2 <- 
  baseg +
  geom_shadowtext(data = data[2:1,], bg.r = 1, size = 10, colour = "red") + 
  labs(title = "before: Z is first")

wrap_plots(g1, g2, nrow = 1)
ggsave(filename = "~/plot_before.png", width = 6, height = 4)
```
![plot_before](https://user-images.githubusercontent.com/553642/68202726-874aa600-ffc4-11e9-80f8-c99734a91be5.png)


The changes I propose uses `"X"` to determine the strheight. In addition, it only uses the strheight, so that the shift is the same in all directions. The result is the following:

```r
devtools::load_all(".") # load this PR

g3 <- 
  baseg +
  geom_shadowtext(bg.r = 1, size = 10, colour = "red") + 
  labs(title = "after: I is first")

g4 <- 
  baseg +
  geom_shadowtext(data = data[2:1,], bg.r = 1, size = 10, colour = "red") + 
  labs(title = "after: Z is first")

wrap_plots(g3, g4, nrow = 1)
ggsave(filename = "~/plot_after.png", width = 6, height = 4)
```
![plot_after](https://user-images.githubusercontent.com/553642/68202734-8ade2d00-ffc4-11e9-88ba-32e1151e7d52.png)

