### PR TITLE
add subset in aes for geom_shadowtext

### DIFF
--- a/R/geom-shadowtext.R
+++ b/R/geom-shadowtext.R
@@ -77,13 +77,17 @@ geom_shadowtext <- function(mapping = NULL, data = NULL,
 ##' @author Guangchuang Yu
 GeomShadowText <- ggproto("GeomShadowText", Geom,
                           required_aes = c("x", "y", "label"),
-
                           default_aes = aes(
                               colour = "white", size = 3.88, angle = 0, hjust = 0.5,
                               vjust = 0.5, alpha = NA, family = "", fontface = 1, lineheight = 1.2,
                               bg.colour = "black", bg.r = 0.1
                           ),
-
+                          optional_aes = c("subset"),
+                          setup_data = function(data, params){
+                              if (is.null(data$subset))
+                                  return(data)
+                              data[which(data$subset),]
+                          },
                           draw_panel = function(data, panel_params, coord, parse = FALSE,
                                                 na.rm = FALSE, check_overlap = FALSE) {
                               lab <- data$label

--- a/man/ggproto-shadowtext.Rd
+++ b/man/ggproto-shadowtext.Rd
@@ -6,7 +6,7 @@
 \alias{GeomShadowtext}
 \title{GeomShadowText}
 \format{
-An object of class \code{GeomShadowText} (inherits from \code{Geom}, \code{ggproto}, \code{gg}) of length 5.
+An object of class \code{GeomShadowText} (inherits from \code{Geom}, \code{ggproto}, \code{gg}) of length 7.
 }
 \usage{
 GeomShadowText


### PR DESCRIPTION
to compatible with the `geom_tiplab` of `ggtree`, introduce `subset` in `aes` for `geom_shadowtext`.

```
> library(ggtree)
ggtree v3.3.1  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution. 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> tr <- rtree(10)
> tr$node.label <- paste0("n", seq_len(9))
> tr

Phylogenetic tree with 10 tips and 9 internal nodes.

Tip labels:
  t5, t3, t7, t10, t1, t9, ...
Node labels:
  n1, n2, n3, n4, n5, n6, ...

Rooted; includes branch lengths.
> tr %>% ggtree()
> tr %>% ggtree() + geom_tiplab(geom="shadowtext")
```

![xx](https://user-images.githubusercontent.com/17870644/148336289-e2f04b8f-9249-4ac0-b1ab-86bfaa73b3d4.PNG)
