### PR TITLE
inline `add_margins()`

### DIFF
--- a/R/element_shadowtext.R
+++ b/R/element_shadowtext.R
@@ -106,6 +106,53 @@ shadow.title_spec <- function (label, x, y, hjust, vjust, angle, gp = gpar(), de
 "%||%" <- getFromNamespace("%||%", "ggplot2")
 zeroGrob <- getFromNamespace("zeroGrob", "ggplot2")
 modify_list <- getFromNamespace("modify_list", "ggplot2")
-add_margins <- getFromNamespace("add_margins", "ggplot2")
 rotate_just <- getFromNamespace("rotate_just", "ggplot2")
 font_descent <- getFromNamespace("font_descent", "ggplot2")
+
+add_margins <- function(grob, height, width, margin = NULL,
+                        gp = gpar(), margin_x = FALSE, margin_y = FALSE) {
+
+    if (is.null(margin)) {
+        margin <- margin(0, 0, 0, 0)
+    }
+
+    if (margin_x & margin_y) {
+        widths  <- grid::unit.c(margin[4], width, margin[2])
+        heights <- grid::unit.c(margin[1], height, margin[3])
+
+        vp <- grid::viewport(
+            layout = grid::grid.layout(3, 3, heights = heights, widths = widths),
+            gp = gp
+        )
+        child_vp <- grid::viewport(layout.pos.row = 2, layout.pos.col = 2)
+    } else if (margin_x) {
+        widths <- grid::unit.c(margin[4], width, margin[2])
+        vp <- grid::viewport(layout = grid::grid.layout(1, 3, widths = widths), gp = gp)
+        child_vp <- grid::viewport(layout.pos.col = 2)
+        heights <- unit(1, "null")
+    } else if (margin_y) {
+        heights <- grid::unit.c(margin[1], height, margin[3])
+        vp <- grid::viewport(layout = grid::grid.layout(3, 1, heights = heights), gp = gp)
+        child_vp <- grid::viewport(layout.pos.row = 2)
+        widths <- unit(1, "null")
+    } else {
+        widths <- width
+        heights <- height
+        return(
+            grid::gTree(
+                children = grob,
+                widths = widths,
+                heights = heights,
+                cl = "titleGrob"
+            )
+        )
+    }
+
+    grid::gTree(
+        children = grob,
+        vp = grid::vpTree(vp, grid::vpList(child_vp)),
+        widths = widths,
+        heights = heights,
+        cl = "titleGrob"
+    )
+}


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break shadowtext.

This PR copies the contents of the removed `add_margins()` function. Briefly, the use of unexported functions is discouraged, as ggplot2 makes no that they continue to exist. For more information about this issue, please see https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/. While `add_margins()` is the one that broke shadowtext this time, there are others that are equally brittle found here:

https://github.com/GuangchuangYu/shadowtext/blob/b810ebcba616ef0d6c011ed97860c8fe2f5f84bb/R/element_shadowtext.R#L106-L111


To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help shadowtext get out a fix if necessary.